### PR TITLE
add ASF DOAP file (Description of a Project)

### DIFF
--- a/doap_Brooklyn.rdf
+++ b/doap_Brooklyn.rdf
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+  <Project rdf:about="http://brooklyn.apache.org">
+    <created>2016-02-23</created>
+    <license rdf:resource="http://spdx.org/licenses/Apache-2.0" />
+    <name>Apache Brooklyn</name>
+    <homepage rdf:resource="http://brooklyn.apache.org" />
+    <asfext:pmc rdf:resource="https://svn.apache.org/repos/asf/comdev/projects.apache.org/data/committees/brooklyn.rdf" />
+    <shortdesc>Apache Brooklyn is a framework for modeling, monitoring, and managing applications through autonomic blueprints.</shortdesc>
+    <description>Apache Brooklyn is a framework for modeling, monitoring, and managing applications through autonomic blueprints.
+
+        Blueprints written in YAML describe your application and are composed from the dozens of supported components and
+        your own components using Bash, Java, Puppet, Chef etc.
+
+        Multi-tiered applications described in Blueprints can be deployed, configured and integrated across 20+ public
+        clouds (Amazon EC2, CloudStack, OpenStack, SoftLayer and many more), private clouds, Docker containers or bare
+        servers.
+
+        Once deployed Apache Brooklyn monitors key application metrics to provide dynamic policy management, including
+        autoscaling to meet demand, and resilisancy though replacing/restarting failed components.
+
+        Management of Apache Brooklyn is made possible via a dynamic web console, rich REST API and simple yet powerful
+        command line interface.</description>
+    <bug-database rdf:resource="https://issues.apache.org/jira/browse/BROOKLYN/" />
+    <mailing-list rdf:resource="http://brooklyn.apache.org/community/mailing-lists.html" />
+    <download-page rdf:resource="http://brooklyn.apache.org/download/index.html" />
+    <programming-language>Java</programming-language>
+    <category rdf:resource="http://projects.apache.org/category/cloud" />
+    <release>
+      <Version>
+        <name>Brooklyn 0.8.0-incubating</name>
+        <created>2015-09-14</created>
+        <revision>0.8.0-incubating</revision>
+      </Version>
+    </release>
+    <release>
+      <Version>
+        <name>Brooklyn 0.7.0-incubating</name>
+        <created>2015-07-15</created>
+        <revision>0.7.0-incubating</revision>
+      </Version>
+    </release>
+    <repository>
+      <GitRepository>
+        <location rdf:resource="https://git-wip-us.apache.org/repos/asf/brooklyn.git"/>
+        <browse rdf:resource="https://git-wip-us.apache.org/repos/asf?p=brooklyn.git"/>
+      </GitRepository>
+    </repository>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Richard Downer</foaf:name>
+          <foaf:mbox rdf:resource="mailto:richard.downer@cloudsoftcorp.com "/>
+      </foaf:Person>
+    </maintainer>
+  </Project>
+</rdf:RDF>

--- a/doap_Brooklyn.rdf
+++ b/doap_Brooklyn.rdf
@@ -28,20 +28,9 @@
     <homepage rdf:resource="http://brooklyn.apache.org" />
     <asfext:pmc rdf:resource="https://svn.apache.org/repos/asf/comdev/projects.apache.org/data/committees/brooklyn.rdf" />
     <shortdesc>Apache Brooklyn is a framework for modeling, monitoring, and managing applications through autonomic blueprints.</shortdesc>
-    <description>Apache Brooklyn is a framework for modeling, monitoring, and managing applications through autonomic blueprints.
-
-        Blueprints written in YAML describe your application and are composed from the dozens of supported components and
-        your own components using Bash, Java, Puppet, Chef etc.
-
-        Multi-tiered applications described in Blueprints can be deployed, configured and integrated across 20+ public
-        clouds (Amazon EC2, CloudStack, OpenStack, SoftLayer and many more), private clouds, Docker containers or bare
-        servers.
-
-        Once deployed Apache Brooklyn monitors key application metrics to provide dynamic policy management, including
-        autoscaling to meet demand, and resilisancy though replacing/restarting failed components.
-
-        Management of Apache Brooklyn is made possible via a dynamic web console, rich REST API and simple yet powerful
-        command line interface.</description>
+    <description>Brooklyn is about deploying and managing applications: composing a full stack for an application;
+        deploying to cloud and non-cloud targets; using monitoring tools to collect key health/performance metrics;
+        responding to situations such as a failing node; and adding or removing capacity to match demand.</description>
     <bug-database rdf:resource="https://issues.apache.org/jira/browse/BROOKLYN/" />
     <mailing-list rdf:resource="http://brooklyn.apache.org/community/mailing-lists.html" />
     <download-page rdf:resource="http://brooklyn.apache.org/download/index.html" />
@@ -69,8 +58,68 @@
     </repository>
     <maintainer>
       <foaf:Person>
+        <foaf:name>Aled Sage</foaf:name>
+          <foaf:mbox rdf:resource="mailto:aledsage@apache.org"/>
+      </foaf:Person>
+    </maintainer>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Alex Heneveld</foaf:name>
+          <foaf:mbox rdf:resource="mailto:heneveld@apache.org"/>
+      </foaf:Person>
+    </maintainer>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Andrea Turli</foaf:name>
+          <foaf:mbox rdf:resource="mailto:andreaturli@apache.org"/>
+      </foaf:Person>
+    </maintainer>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Andrew Kennedy</foaf:name>
+          <foaf:mbox rdf:resource="mailto:grkvlt@apache.org"/>
+      </foaf:Person>
+    </maintainer>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Ciprian Ciubotariu</foaf:name>
+          <foaf:mbox rdf:resource="mailto:cipi@apache.org"/>
+      </foaf:Person>
+    </maintainer>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Hadrian Zbarcea</foaf:name>
+          <foaf:mbox rdf:resource="mailto:hadrian@apache.org"/>
+      </foaf:Person>
+    </maintainer>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Jean-Baptiste Onofré</foaf:name>
+          <foaf:mbox rdf:resource="mailto:jbonofre@apache.org"/>
+      </foaf:Person>
+    </maintainer>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Olivier Lamy</foaf:name>
+          <foaf:mbox rdf:resource="mailto:olamy@apache.org"/>
+      </foaf:Person>
+    </maintainer>
+    <maintainer>
+      <foaf:Person>
         <foaf:name>Richard Downer</foaf:name>
-          <foaf:mbox rdf:resource="mailto:richard.downer@cloudsoftcorp.com "/>
+          <foaf:mbox rdf:resource="mailto:richard@apache.org"/>
+      </foaf:Person>
+    </maintainer>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Sam Corbett</foaf:name>
+          <foaf:mbox rdf:resource="mailto:sjcorbett@apache.org"/>
+      </foaf:Person>
+    </maintainer>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Svetoslav Neykov</foaf:name>
+          <foaf:mbox rdf:resource="mailto:svet@apache.org"/>
       </foaf:Person>
     </maintainer>
   </Project>


### PR DESCRIPTION
- https://projects.apache.org/project.html?brooklyn
- https://projects-old.apache.org/doap.html

@rdowner @ahgittin @aledsage - can you review please, I suspect the long description needs overhaul (pretty much a carbon copy from the website)

I suggest we use the following URL to specify the location of the DOAP file, gives us flexibility when updating.

- https://git1-us-west.apache.org/repos/asf?p=brooklyn.git;a=blob_plain;f=doap_Brooklyn.rdf;hb=HEAD