### PR TITLE
add the go CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ get this project and its sub-modules:
     git submodule init
     git submodule update --remote --merge --recursive
     
-And then:
+And then, with jdk 1.8+, maven 3.1+, and go 1.6+ installed (or skip go with `-Dno-go-client`):
 
     mvn clean install
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,34 @@
         <module>brooklyn-ui</module>
         <module>brooklyn-server</module>
         <module>brooklyn-library</module>
-        <module>brooklyn-client</module>
-        <module>brooklyn-dist</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <!-- skip the client CLI by setting -Dno-go-client - useful if Go is not available -->
+            <id>go-client</id>
+            <activation>
+                <property>
+                    <name>!no-go-client</name>
+                </property>
+            </activation>
+            <modules>
+                <module>brooklyn-client</module>
+            </modules>
+        </profile>
+        <profile>
+            <!-- also build the dist with a profile; we don't really expect people to opt in to skip, though they can;
+                 mainly this is here to ensure the go-client profile modules if included get built before the dist module -->
+            <id>dist</id>
+            <activation>
+                <property>
+                    <name>!no-dist</name>
+                </property>
+            </activation>
+            <modules>
+                <module>brooklyn-dist</module>
+            </modules>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION

builds on @geomacy's work, extending so that:

* uses a property -Dno-go-client to suppress building the go client
* removes the version from the name of client cli folder in the dist
* switches from `src/main` for go cli project license/files to `build/`
* tidies how `NOTICE` files are generated
* improves docs and README, including the above and others

this depends on three other PR's:

* https://github.com/apache/brooklyn-client/pull/5
* https://github.com/apache/brooklyn-dist/pull/15
* https://github.com/apache/brooklyn-docs/pull/26

this includes and builds on the following:

* https://github.com/apache/brooklyn-client/pull/4
* https://github.com/apache/brooklyn-dist/pull/14
* https://github.com/apache/brooklyn-docs/pull/25
* https://github.com/apache/brooklyn/pull/5
