### PR TITLE
Add dockerfile for CI build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# For all Brooklyn, we use a debian distribution instead of alpine as there are some libgcc incompatibilities with GO
+# and PhantomJS
+FROM maven:3.5.2-jdk-8-slim
+
+# Install the non-headless JRE as some tests requires them
+RUN apt-get update && apt-get install -y openjdk-8-jre
+
+# Install necessary binaries to build brooklyn
+RUN apt-get update && apt-get install -y \
+    git-core \
+    procps \
+    golang-go \
+    rpm \
+    dpkg

--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ get this project and its sub-modules:
     
 And then, with jdk 1.8+ and maven 3.1+ installed:
 
-    mvn clean install -Dno-go-client -Dno-rpm
+    mvn clean install -Dno-go-client -Dno-rpm -Dno-deb
+
+However, you won't be able to build the RPM/DEB packages, as well as the CLI. That's why we would recommand to use the
+alternative: a docker container to build this project:
+
+```bash
+docker build -t brooklyn .
+docker run -i --rm --name brooklyn -v ${HOME}/.m2:/root/.m2 -v ${PWD}:/usr/build -w /usr/build brooklyn mvn clean install
+```
 
 The results are in `brooklyn-dist/dist/target/`, including a tar and a zip.
 Or to run straight after the build, do:
@@ -37,7 +45,7 @@ Or to run straight after the build, do:
 ### Resources
 
 <!--- BROOKLYN_VERSION_BELOW -->
-The **[Developers](https://brooklyn.apache.org/developers/)** section of the main website contains more detail on working with the codebase. There is also a more **Developer Guide** specific to each version, including [this branch (0.13.0-SNAPSHOT)](https://brooklyn.apache.org/v/0.13.0-SNAPSHOT/dev/), [latest stable](https://brooklyn.apache.org/v/latest/dev/), and [older releases](https://brooklyn.apache.org/meta/versions.html).
+The **[Developers](https://brooklyn.apache.org/developers/)** section of the main website contains more detail on working with the codebase. There is also a more **Developer Guide** specific to each version, including [this branch (1.0.0-SNAPSHOT)](https://brooklyn.apache.org/v/1.0.0-SNAPSHOT/dev/), [latest stable](https://brooklyn.apache.org/v/latest/dev/), and [older releases](https://brooklyn.apache.org/meta/versions.html).
 
 Useful topics include:
 
@@ -48,7 +56,7 @@ Useful topics include:
 * the **[maven build](http://brooklyn.apache.org/v/latest/dev/env/maven-build.html)** and what to do on build errors
 
 <!--- BROOKLYN_VERSION_BELOW -->
-* **[project structure](https://brooklyn.apache.org/v/0.13.0-SNAPSHOT/dev/code/structure.html)** of the codebase and submodules
+* **[project structure](https://brooklyn.apache.org/v/1.0.0-SNAPSHOT/dev/code/structure.html)** of the codebase and submodules
 
 * the **[people](https://brooklyn.apache.org/community/)** behind Apache Brooklyn
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.apache.brooklyn</groupId>
     <artifactId>brooklyn</artifactId>
-    <version>0.13.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+    <version>1.0.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
     <packaging>pom</packaging>
 
     <name>Brooklyn Root</name>


### PR DESCRIPTION
As per as the [ML discussion](https://lists.apache.org/thread.html/c97846e172d327e72eb286e3c032c26fc0d6642dc553a4b47494177c@%3Cdev.brooklyn.apache.org%3E), this adds the `Dockerfile` to build the project. It also adds instructions on how to use it.