### PR TITLE
edit Brooklyn license info so that GitHub recognizes it

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,3 @@
-
-This software is distributed under the Apache License, version 2.0. See (1) below.
-This software is copyright (c) The Apache Software Foundation and contributors.
-
-Contents:
-
-  (1) This software license: Apache License, version 2.0
-  (2) Notices for bundled software
-  (3) Licenses for bundled software
-
-
----------------------------------------------------
-
-(1) This software license: Apache License, version 2.0
-
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -189,6 +173,32 @@ Contents:
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
 
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
 ---------------------------------------------------
 
@@ -686,5 +696,3 @@ The MIT License ("MIT")
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
-  
-

--- a/README.md
+++ b/README.md
@@ -60,3 +60,6 @@ Useful topics include:
 
 * the **[people](https://brooklyn.apache.org/community/)** behind Apache Brooklyn
 
+### License
+
+This software is distributed under the Apache License, version 2.0, copyright (c) The Apache Software Foundation and contributors. Please see the LICENSE file for (1) the full text of the Apache License, followed by (2) notices for bundled software and (3) licenses for bundled software.


### PR DESCRIPTION
Hello! 👋

(CCing @dankohn who has requested this work so that the license will appear correctly in https://landscape.cncf.io/selected=apache-brooklyn)

GitHub uses a library called Licensee to identify a project's license
type. It shows this information in the status bar and via the API if it
can unambiguously identify the license.

This commit updates the LICENSE file so that it begins with the full
text of the Apache license (including the Appendix). The text that
preceded the beginning of the license text has been transferred to a
new "License" section in the README.

Collectively, these changes allow Licensee to successfully identify the
license type of Brooklyn as Apache 2.0.

REFS: [BROOKLYN-593](https://issues.apache.org/jira/browse/BROOKLYN-593)