### PR TITLE
switch order of build, so server before ui

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
     </mailingLists>
 
     <modules>
-        <module>brooklyn-ui</module>
         <module>brooklyn-server</module>
+        <module>brooklyn-ui</module>
         <module>brooklyn-library</module>
     </modules>
 


### PR DESCRIPTION
needed because ui modularity server depends on brooklyn server java;
fortunately ui is no longer needed for brooklyn server so this is safe.

Needed as part of the batch of changes consequence of https://github.com/apache/brooklyn-ui/pull/54 .