### PR TITLE
Jenkins: use pipeline, and don’t bind-mount .m2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,8 @@ RUN apt-get update && apt-get install -y \
     dpkg \
     pkg-config \
     nasm \
-    gcc \
+    gcc
+
+# For mvn-build
+RUN mkdir -p /var/maven/.m2/ && chmod -R 777 /var/maven/
+ENV MAVEN_CONFIG=/var/maven/.m2

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+node(label: 'ubuntu') {
+    catchError {
+        def environmentDockerImage
+
+        def dockerTag = env.BUILD_TAG.replace('%2F', '-')
+
+        withEnv(["DOCKER_TAG=${dockerTag}"]) {
+            stage('Clone repository') {
+                checkout scm
+            }
+
+            stage('Prepare environment') {
+                echo 'Creating maven cache ...'
+                sh 'mkdir -p ${WORKSPACE}/.m2'
+                sh 'git submodule update --remote --merge --recursive'
+                echo 'Building docker image for test environment ...'
+                environmentDockerImage = docker.build('brooklyn:${DOCKER_TAG}')
+            }
+
+            stage('Run tests') {
+                environmentDockerImage.inside('-i --rm --name brooklyn-${DOCKER_TAG} -u 910:910 --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
+                    sh 'mvn clean install -Duser.home=/var/maven -Duser.name=$(id -un 910)'
+                }
+            }
+
+            // Conditional stage to deploy artifacts, when not building a PR
+            if (env.CHANGE_ID == null) {
+                stage('Deploy artifacts') {
+                    environmentDockerImage.inside('-i --rm --name brooklyn-${DOCKER_TAG} -u 910:910 --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
+                        sh 'mvn deploy -DskipTests -Duser.home=/var/maven -Duser.name=$(id -un 910)'
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- Post actions steps, to always perform ----
+
+    stage('Publish test results') {
+        // Publish JUnit results
+        junit allowEmptyResults: true, testResults: '**/target/surefire-reports/junitreports/*.xml'
+
+        // Publish TestNG results
+        step([
+            $class: 'Publisher',
+            reportFilenamePattern: '**/testng-results.xml'
+        ])
+    }
+
+    // Conditional stage, when not building a PR
+    if (env.CHANGE_ID == null) {
+        stage('Send notifications') {
+            // Send email notifications
+            step([
+                $class: 'Mailer',
+                notifyEveryUnstableBuild: true,
+                recipients: 'dev@brooklyn.apache.org',
+                sendToIndividuals: false
+            ])
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ where you'll find:
 
 ### Quick Start
 
-This is the uber-repo. To build the entire codebase, 
+This is the uber-repo. To build the entire codebase,
 get this project and its sub-modules:
 
     git clone http://github.com/apache/brooklyn/
     cd brooklyn
     git submodule init
     git submodule update --remote --merge --recursive
-    
+
 And then, with jdk 1.8+ and maven 3.1+ installed:
 
     mvn clean install -Dno-go-client -Dno-rpm -Dno-deb
@@ -32,7 +32,18 @@ alternative: a docker container to build this project:
 
 ```bash
 docker build -t brooklyn .
-docker run -i --rm --name brooklyn -v ${HOME}/.m2:/root/.m2 -v ${PWD}:/usr/build -w /usr/build brooklyn mvn clean install
+docker run -i --rm --name brooklyn -u $(id -u):$(id -g) \
+      --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly \
+      -v ${PWD}:/usr/build -w /usr/build \
+      brooklyn mvn clean install -Duser.home=/var/maven -Duser.name=$(id -un)
+```
+
+You can speed this up by using your local .m2 cache:
+```bash
+docker run -i --rm --name brooklyn -u $(id -u):$(id -g) \
+      -v ${HOME}/.m2:/var/maven/.m2 \
+      -v ${PWD}:/usr/build -w /usr/build \
+      brooklyn mvn clean install -Duser.home=/var/maven -Duser.name=$(id -un)
 ```
 
 The results are in `brooklyn-dist/dist/target/`, including a tar and a zip.


### PR DESCRIPTION
Copies the configuration approach in https://github.com/apache/brooklyn-library/blob/master/Jenkinsfile, to be used by https://builds.apache.org/view/B/view/Brooklyn/job/brooklyn-master-build-docker-pipeline/