### PR TITLE
Jenkins pipeline: fix `user.name`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ node(label: 'ubuntu') {
 
             stage('Run tests') {
                 environmentDockerImage.inside('-i --rm --name brooklyn-${DOCKER_TAG} -u 910:910 --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
-                    sh 'mvn clean install -Duser.home=/var/maven -Duser.name=$(id -un 910)'
+                    sh 'mvn clean install -Duser.home=/var/maven -Duser.name=jenkins'
                 }
             }
 
@@ -47,7 +47,7 @@ node(label: 'ubuntu') {
             if (env.CHANGE_ID == null) {
                 stage('Deploy artifacts') {
                     environmentDockerImage.inside('-i --rm --name brooklyn-${DOCKER_TAG} -u 910:910 --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
-                        sh 'mvn deploy -DskipTests -Duser.home=/var/maven -Duser.name=$(id -un 910)'
+                        sh 'mvn deploy -DskipTests -Duser.home=/var/maven -Duser.name=jenkins'
                     }
                 }
             }

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ docker run -i --rm --name brooklyn -u $(id -u):$(id -g) \
 The results are in `brooklyn-dist/dist/target/`, including a tar and a zip.
 Or to run straight after the build, do:
 
-    pushd brooklyn-dist/dist/target/brooklyn-dist/brooklyn/
-    bin/brooklyn launch
+```bash
+pushd brooklyn-dist/karaf/apache-brooklyn/target/assembly/
+./bin/start
+```
 
 
 ### Resources


### PR DESCRIPTION
User 910 is unknown in the docker container, so `${id -un 910}` does not return a name. We don’t care what `user.name` it has, as long as there is one.

Otherwise tests in `org.apache.brooklyn.location.jclouds.DefaultConnectivityResolverTest` fail because it didn't find a user name, so goes down a different code path to try to figure it out and set it.