### PR TITLE
jenkins: fix npm build, removing docker -u

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ node(label: 'ubuntu') {
             }
 
             stage('Run tests') {
-                environmentDockerImage.inside('-i --rm --name brooklyn-${DOCKER_TAG} -u 910:910 --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
+                environmentDockerImage.inside('-i --rm --name brooklyn-${DOCKER_TAG} --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
                     sh 'mvn clean install -Duser.home=/var/maven -Duser.name=jenkins'
                 }
             }
@@ -46,7 +46,7 @@ node(label: 'ubuntu') {
             // Conditional stage to deploy artifacts, when not building a PR
             if (env.CHANGE_ID == null) {
                 stage('Deploy artifacts') {
-                    environmentDockerImage.inside('-i --rm --name brooklyn-${DOCKER_TAG} -u 910:910 --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
+                    environmentDockerImage.inside('-i --rm --name brooklyn-${DOCKER_TAG} --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
                         sh 'mvn deploy -DskipTests -Duser.home=/var/maven -Duser.name=jenkins'
                     }
                 }


### PR DESCRIPTION
npm writes to ~/.npm, and reads ~/.npmrc. But user 910 does
not exist in container, so has no home directory. Therefore
npm fails. Reverting `-u` for now.

e.g. https://builds.apache.org/view/B/view/Brooklyn/job/brooklyn-master-build-docker-pipeline/10/console failed with:
```
[INFO] --- frontend-maven-plugin:1.3:npm (npm install) @ brooklyn-ui-utils ---
[INFO] Running 'npm install' in /home/jenkins/jenkins-slave/workspace/brooklyn-master-build-docker-pipeline/brooklyn-ui/ui-modules/utils
[ERROR] Unhandled rejection Error: EACCES: permission denied, mkdir '/.npm'
```

This stackoverflow looks useful for fixing it longer term: https://stackoverflow.com/questions/46129443/sudo-permission-inside-docker-container-for-jenkins-pipeline.

We could `npm config set cache /tmp` and also `export HOME=...`.

Or we could create a user with id 910:910 in the container, as part of the Dockerfile.