### PR TITLE
Update docker instructions to mount the docker socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ get this project and its sub-modules:
 
 And then, with jdk 1.8+ and maven 3.1+ installed:
 
-    mvn clean install -Dno-go-client -Dno-rpm -Dno-deb
+    mvn clean install -Dno-go-client -Dno-rpm -Dno-deb -DskipDocker
 
 However, you won't be able to build the RPM/DEB packages, as well as the CLI. That's why we would recommand to use the
 alternative: a docker container to build this project:
@@ -34,6 +34,7 @@ alternative: a docker container to build this project:
 docker build -t brooklyn .
 docker run -i --rm --name brooklyn -u $(id -u):$(id -g) \
       --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly \
+      -v /var/run/docker.sock:/var/run/docker.sock \
       -v ${PWD}:/usr/build -w /usr/build \
       brooklyn mvn clean install -Duser.home=/var/maven -Duser.name=$(id -un)
 ```
@@ -41,6 +42,7 @@ docker run -i --rm --name brooklyn -u $(id -u):$(id -g) \
 You can speed this up by using your local .m2 cache:
 ```bash
 docker run -i --rm --name brooklyn -u $(id -u):$(id -g) \
+      -v /var/run/docker.sock:/var/run/docker.sock \
       -v ${HOME}/.m2:/var/maven/.m2 \
       -v ${PWD}:/usr/build -w /usr/build \
       brooklyn mvn clean install -Duser.home=/var/maven -Duser.name=$(id -un)


### PR DESCRIPTION
This is because https://github.com/apache/brooklyn-dist/pull/118 now build docker, therefore the container needs to be able to access the docker engine on the host