### PR TITLE
Make the go cli optional by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,11 @@
 
     <profiles>
         <profile>
-            <!-- skip the client CLI by setting -Dno-go-client - useful if Go is not available -->
-            <id>go-client</id>
+            <!-- Include the client CLI by setting -Dclient -->
+            <id>client</id>
             <activation>
                 <property>
-                    <name>!no-go-client</name>
+                    <name>client</name>
                 </property>
             </activation>
             <modules>


### PR DESCRIPTION
This disables by default the build of `brooklyn-client`. It can be reenabled by doing:
```
mvn clean install -Dclient
```

This is to fix the inconsistency pointed out in this email thread: https://lists.apache.org/thread.html/f296ff5ed96002f165bdef95d0aac083261ff44c78c24c0a804fe4d9@%3Cdev.brooklyn.apache.org%3E
