### PR TITLE
Build brooklyn when any downstream projects is successfully built

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node(label: 'ubuntu') {
     if (env.BRANCH_NAME == 'master') {
         triggers.push(upstream(
             threshold: 'SUCCESS',
-            upstreamProjects: '../brooklyn-server/master, ../brooklyn-library/master, ../brooklyn-ui/master, ../brooklyn-client/master, ../brooklyn-dist/master'
+            upstreamProjects: 'brooklyn-server/master, brooklyn-library/master, brooklyn-ui/master, brooklyn-client/master, brooklyn-dist/master'
         ))
     }
 


### PR DESCRIPTION
As per as the previous jenkins configuration, Brooklyn should be fully tested and built when any of the git subrepo (e.g. `brooklyn-server`, `brooklyn-library`, etc) is built.

The previous version was working on the assumption that the path to the jenkins upstream projects should be relative but in fact, it should just be `<project-name>/<branch>`