### PR TITLE
Bumps maven version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 
 # For all Brooklyn, we use a debian distribution instead of alpine as there are some libgcc incompatibilities with GO
 # and PhantomJS
-FROM maven:3.5.4-jdk-8
+FROM maven:3.6.3-jdk-8
 
 # Install the non-headless JRE as some tests requires them
 RUN apt-get update && apt-get install -y openjdk-8-jre


### PR DESCRIPTION
3.5.4 is no longer a supported tag. This bumps the version to the latest supported tag at https://hub.docker.com/_/maven