### PR TITLE
Fix docker build by reverting to docker image maven:3.5.4-jdk-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 
 # For all Brooklyn, we use a debian distribution instead of alpine as there are some libgcc incompatibilities with GO
 # and PhantomJS
-FROM maven:3.6.3-jdk-8
+FROM maven:3.5.4-jdk-8
 
 # Install the non-headless JRE as some tests requires them
 RUN apt-get update && apt-get install -y openjdk-8-jre


### PR DESCRIPTION
#42 attempted to work around the new version of the docker image `maven:3.6.3-jdk-8`. While the docker build works, the tests fail, probably due to the non-conventional place openjdk is installed:
```
Tests run: 2366, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 266.727 sec <<< FAILURE! - in TestSuite
testInjectCertificateAuthority(org.apache.brooklyn.util.core.crypto.SecureKeysAndSignerTest)  Time elapsed: 0.542 sec  <<< FAILURE!
java.lang.AssertionError: expected [true] but found [false]
	at org.apache.brooklyn.util.core.crypto.SecureKeysAndSignerTest.testInjectCertificateAuthority(SecureKeysAndSignerTest.java:89)

2020-02-11 12:04:39,960 INFO  - Brooklyn shutdown: stopping entities [TestEntityImpl{id=zx63bdhkyl}, TestEntityImpl{id=es2g7mt1un}, BlockingEntityImpl{id=wrqs7d7pht}]
Results :

Failed tests: 
  SecureKeysAndSignerTest.testInjectCertificateAuthority:89 expected [true] but found [false]

Tests run: 2366, Failures: 1, Errors: 0, Skipped: 0
```

So this reverts the the known working version for the docker build.

This closes #42 