### PR TITLE
Don't install openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,6 @@
 # and PhantomJS
 FROM maven:3.6.3-jdk-8
 
-# Install the non-headless JRE as some tests requires them
-RUN apt-get update && apt-get install -y openjdk-8-jre
-
 # Install necessary binaries to build brooklyn
 # Strictly speaking, rsync, gpg, tar, and zip are only necessary
 # if you are creating release artifacts, but they are fairly


### PR DESCRIPTION
The source image already includes a version of openjdk-8. Removing this command as it fails due to the package not being available from the software repos.