### PR TITLE
Fix brooklyn-client build issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ node(label: 'ubuntu') {
 
             stage('Run tests') {
                 environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -v ${WORKSPACE}/.m2:/var/maven/.m2 --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
-                    sh 'mvn clean install -Prpm -Pdeb -Duser.home=/var/maven -Duser.name=jenkins'
+                    sh 'MAVEN_OPTS="-Xmx8g" ; mvn clean install -Prpm -Pdeb -Pclient -Duser.home=/var/maven -Duser.name=jenkins'
                 }
             }
 
@@ -62,7 +62,7 @@ node(label: 'ubuntu') {
             if (env.CHANGE_ID == null) {
                 stage('Deploy artifacts') {
                     environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -v ${WORKSPACE}/.m2:/var/maven/.m2 --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
-                        sh 'mvn deploy -Prpm -Pdeb -DskipTests -Duser.home=/var/maven -Duser.name=jenkins'
+                        sh 'MAVEN_OPTS="-Xmx8g" mvn deploy -Prpm -Pdeb -Pclient -DskipTests -Duser.home=/var/maven -Duser.name=jenkins'
                     }
                 }
             }


### PR DESCRIPTION
Change `brooklyn-ui` submodule reference from https://github.com/apache/brooklyn-ui/tree/06562e931e6f208bbb897f17893baeae046154bf which doesn't exist, to current master https://github.com/apache/brooklyn-ui/commit/0b40be5b8f345356c59bf0ccfa36575a612d4713 and increase memory requirements for the build to allow `brooklyn-client` build to execute.