### PR TITLE
Revert "Fix brooklyn-client build issue"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ node(label: 'ubuntu') {
 
             stage('Run tests') {
                 environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -v ${WORKSPACE}/.m2:/var/maven/.m2 --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
-                    sh 'MAVEN_OPTS="-Xmx8g" ; mvn clean install -Prpm -Pdeb -Pclient -Duser.home=/var/maven -Duser.name=jenkins'
+                    sh 'mvn clean install -Prpm -Pdeb -Duser.home=/var/maven -Duser.name=jenkins'
                 }
             }
 
@@ -62,7 +62,7 @@ node(label: 'ubuntu') {
             if (env.CHANGE_ID == null) {
                 stage('Deploy artifacts') {
                     environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -v ${WORKSPACE}/.m2:/var/maven/.m2 --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
-                        sh 'MAVEN_OPTS="-Xmx8g" mvn deploy -Prpm -Pdeb -Pclient -DskipTests -Duser.home=/var/maven -Duser.name=jenkins'
+                        sh 'mvn deploy -Prpm -Pdeb -DskipTests -Duser.home=/var/maven -Duser.name=jenkins'
                     }
                 }
             }


### PR DESCRIPTION
Reverts apache/brooklyn#50

The build fails with `GC overhead limit exceeded -> [Help 1]`. Apparently 8GB is not enough. 
