### PR TITLE
Tell docker build where to find openssl libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 
 # For all Brooklyn, we use a debian distribution instead of alpine as there are some libgcc incompatibilities with GO
 # and PhantomJS
-FROM maven:3.8.2-jdk-8
+FROM maven:3.8.6-jdk-8
 
 # Install necessary binaries to build brooklyn
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ RUN mkdir -p /var/tmp/ && chmod -R 777 /var/tmp/
 # Make sure the /var/maven is writable for all users
 RUN mkdir -p /var/maven/.m2/ && chmod -R 777 /var/maven/
 ENV MAVEN_CONFIG=/var/maven/.m2
-
+ENV OPENSSL_CONF=/etc/ssl


### PR DESCRIPTION
Adds and environment variable to the Dockerfile to allow PhantonJS to fidn the openssl libraries.

PhantomJS was failing to start while building `Brooklyn UI :: Modules - UI Utils` due to not finding the openssl libraries:

```
...
[INFO] 27 01 2023 18:59:33.425:INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
[INFO] 27 01 2023 18:59:33.429:INFO [launcher]: Launching browser PhantomJS with unlimited concurrency
[INFO] 27 01 2023 18:59:33.468:INFO [launcher]: Starting browser PhantomJS
[INFO] 27 01 2023 18:59:34.107:ERROR [phantomjs.launcher]: Auto configuration failed
[INFO] 139632705259456:error:25066067:DSO support routines:DLFCN_LOAD:could not load the shared library:dso_dlfcn.c:185:filename(libssl_conf.so): libssl_conf.so: cannot open shared object file: No such file or directory
[INFO] 139632705259456:error:25070067:DSO support routines:DSO_load:could not load the shared library:dso_lib.c:244:
[INFO] 139632705259456:error:0E07506E:configuration file routines:MODULE_LOAD_DSO:error loading dso:conf_mod.c:285:module=ssl_conf, path=ssl_conf
[INFO] 139632705259456:error:0E076071:configuration file routines:MODULE_RUN:unknown module name:conf_mod.c:222:module=ssl_conf
[INFO] 
[INFO] 27 01 2023 18:59:34.108:ERROR [launcher]: Cannot start PhantomJS
...
```